### PR TITLE
Fix micro cam deployments

### DIFF
--- a/30-apps/micro-cam/k8s/camera-uploader.yaml
+++ b/30-apps/micro-cam/k8s/camera-uploader.yaml
@@ -8,6 +8,7 @@ spec:
   resources:
     requests:
       storage: 2Gi
+  storageClassName: local-path
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/30-apps/micro-cam/k8s/relay.yaml
+++ b/30-apps/micro-cam/k8s/relay.yaml
@@ -19,7 +19,7 @@ spec:
           - |
             set -eux
             # RTSP pseudo-stream from refreshed JPEG
-            ffmpeg -re -r 5 -f image2 -i http://camera-uploader.suite.home.arpa/latest.jpg \
+            ffmpeg -re -r 5 -f image2 -i http://camera-uploader.suite.svc.cluster.local/latest.jpg \
               -vf "fps=5,format=yuv420p" \
               -f rtsp rtsp://0.0.0.0:8554/porch
         ports:


### PR DESCRIPTION
## Summary
- add explicit storage class for the camera uploader persistent volume claim
- point the relay ffmpeg input at the in-cluster service instead of the external ingress host

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68ceb27937788322a6de11a1a4943533