### PR TITLE
Fix micro-cam relay command override

### DIFF
--- a/30-apps/micro-cam/helm/micro-cam/templates/all.yaml
+++ b/30-apps/micro-cam/helm/micro-cam/templates/all.yaml
@@ -79,9 +79,10 @@ spec:
       containers:
       - name: ffmpeg
         image: jrottenberg/ffmpeg:6-alpine
-        args:
+        command:
           - /bin/sh
-          - -lc
+          - -c
+        args:
           - |
             set -eux
             ffmpeg -re -r 5 -f image2 -i http://camera-uploader.{{ .Values.namespace }}.svc.cluster.local/latest.jpg \

--- a/30-apps/micro-cam/k8s/relay.yaml
+++ b/30-apps/micro-cam/k8s/relay.yaml
@@ -13,9 +13,10 @@ spec:
       containers:
       - name: ffmpeg
         image: jrottenberg/ffmpeg:6-alpine
-        args:
+        command:
           - /bin/sh
-          - -lc
+          - -c
+        args:
           - |
             set -eux
             # RTSP pseudo-stream from refreshed JPEG


### PR DESCRIPTION
## Summary
- ensure the relay deployment overrides the ffmpeg container entrypoint with /bin/sh -c
- mirror the command override in the Helm template so both manifests align

## Testing
- not run (not feasible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cec566470c8322bc738a8234012dae