### PR TITLE
Fix micro-cam relay ffmpeg command

### DIFF
--- a/30-apps/micro-cam/helm/micro-cam/templates/all.yaml
+++ b/30-apps/micro-cam/helm/micro-cam/templates/all.yaml
@@ -85,9 +85,10 @@ spec:
         args:
           - |
             set -eux
-            ffmpeg -re -r 5 -f image2 -i http://camera-uploader.{{ .Values.namespace }}.svc.cluster.local/latest.jpg \
+            ffmpeg -re -r 5 -f image2 \
+              -i "http://camera-uploader.{{ .Values.namespace }}.svc.cluster.local/latest.jpg" \
               -vf "fps=5,format=yuv420p" \
-              -f rtsp rtsp://0.0.0.0:8554/porch
+              -f rtsp -listen 1 rtsp://0.0.0.0:8554/porch
         ports: [{containerPort: 8554, name: rtsp}]
 ---
 apiVersion: v1

--- a/30-apps/micro-cam/k8s/relay.yaml
+++ b/30-apps/micro-cam/k8s/relay.yaml
@@ -20,9 +20,10 @@ spec:
           - |
             set -eux
             # RTSP pseudo-stream from refreshed JPEG
-            ffmpeg -re -r 5 -f image2 -i http://camera-uploader.suite.svc.cluster.local/latest.jpg \
+            ffmpeg -re -r 5 -f image2 \
+              -i "http://camera-uploader.suite.svc.cluster.local/latest.jpg" \
               -vf "fps=5,format=yuv420p" \
-              -f rtsp rtsp://0.0.0.0:8554/porch
+              -f rtsp -listen 1 rtsp://0.0.0.0:8554/porch
         ports:
         - containerPort: 8554
           name: rtsp


### PR DESCRIPTION
## Summary
- update the micro-cam relay deployment to quote the image input URL
- add the listen flag so ffmpeg serves the RTSP stream instead of treating the URL as an option

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ced477c3f88322b448a3d0adbcc706