### PR TITLE
fix: run ffmpeg relay without shell wrapper

### DIFF
--- a/30-apps/micro-cam/helm/micro-cam/templates/all.yaml
+++ b/30-apps/micro-cam/helm/micro-cam/templates/all.yaml
@@ -79,15 +79,20 @@ spec:
       containers:
       - name: ffmpeg
         image: jrottenberg/ffmpeg:6-alpine
-        command:
-          - /bin/sh
-          - -c
+        command: [ffmpeg]
         args:
-          - |
-            set -eux
-            ffmpeg -re -r 5 -f image2 -i http://camera-uploader.{{ .Values.namespace }}.svc.cluster.local/latest.jpg \
-              -vf "fps=5,format=yuv420p" \
-              -f rtsp rtsp://0.0.0.0:8554/porch
+          - -re
+          - -r
+          - "5"
+          - -f
+          - image2
+          - -i
+          - http://camera-uploader.{{ .Values.namespace }}.svc.cluster.local/latest.jpg
+          - -vf
+          - fps=5,format=yuv420p
+          - -f
+          - rtsp
+          - rtsp://0.0.0.0:8554/porch
         ports: [{containerPort: 8554, name: rtsp}]
 ---
 apiVersion: v1

--- a/30-apps/micro-cam/k8s/relay.yaml
+++ b/30-apps/micro-cam/k8s/relay.yaml
@@ -13,16 +13,20 @@ spec:
       containers:
       - name: ffmpeg
         image: jrottenberg/ffmpeg:6-alpine
-        command:
-          - /bin/sh
-          - -c
+        command: [ffmpeg]
         args:
-          - |
-            set -eux
-            # RTSP pseudo-stream from refreshed JPEG
-            ffmpeg -re -r 5 -f image2 -i http://camera-uploader.suite.svc.cluster.local/latest.jpg \
-              -vf "fps=5,format=yuv420p" \
-              -f rtsp rtsp://0.0.0.0:8554/porch
+          - -re
+          - -r
+          - "5"
+          - -f
+          - image2
+          - -i
+          - http://camera-uploader.suite.svc.cluster.local/latest.jpg
+          - -vf
+          - fps=5,format=yuv420p
+          - -f
+          - rtsp
+          - rtsp://0.0.0.0:8554/porch
         ports:
         - containerPort: 8554
           name: rtsp


### PR DESCRIPTION
## Summary
- invoke the micro-cam relay container with ffmpeg directly instead of via /bin/sh
- provide ffmpeg arguments explicitly so no stray shell options get passed through

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ced477c3f88322b448a3d0adbcc706