### PR TITLE
Add Terraform scripts for AWS and libvirt K3s workers

### DIFF
--- a/60-terraform/k3s-workers/.gitignore
+++ b/60-terraform/k3s-workers/.gitignore
@@ -1,0 +1,1 @@
+rendered/

--- a/60-terraform/k3s-workers/README.md
+++ b/60-terraform/k3s-workers/README.md
@@ -1,0 +1,88 @@
+# K3s Worker Server Deployment
+
+This Terraform configuration provisions two free-tier friendly worker nodes and joins them to an existing K3s control-plane:
+
+* **Cloud worker** – AWS EC2 `t2.micro` instance (eligible for the AWS Free Tier) running Amazon Linux 2023.
+* **On-prem worker** – KVM/libvirt virtual machine created on your own hardware using an Ubuntu 22.04 cloud image (free to use).
+
+Both nodes are bootstrapped with the K3s agent and connect back to an existing K3s server using the URL and token that you supply.
+
+> ⚠️  Nothing in this repository creates paid resources by default, but you are responsible for reviewing and adjusting the variables before you run `terraform apply` to ensure you stay within the limits of the free offerings from your cloud and on-prem environments.
+
+## Prerequisites
+
+1. [Terraform](https://developer.hashicorp.com/terraform/downloads) v1.5 or newer.
+2. AWS credentials with permission to create EC2 instances, security groups, and key pair associations. The defaults target the free-tier `t2.micro` size in `us-east-1`.
+3. A libvirt/KVM host (for example, a workstation or server running Ubuntu Server) with:
+   - An Ubuntu 22.04 cloud image (`ubuntu-22.04-server-cloudimg-amd64.img`) already downloaded into a libvirt storage pool.
+   - A libvirt network that can reach your K3s control-plane endpoint.
+4. The K3s control-plane URL (e.g., `https://10.0.0.10:6443`) and the shared cluster token. These values are required for both workers to successfully register.
+5. An SSH key pair registered in AWS and the matching public key available for the libvirt VM.
+
+## Directory layout
+
+```
+60-terraform/k3s-workers/
+├── cloud.tf
+├── onprem.tf
+├── outputs.tf
+├── providers.tf
+├── templates/
+│   ├── cloud-init.yaml.tftpl
+│   └── k3s-agent.sh.tftpl
+└── variables.tf
+```
+
+## Usage
+
+1. Copy `terraform.tfvars.example` (generated automatically after your first `terraform apply`) or create a new `terraform.tfvars` file with the variables shown in [`variables.tf`](./variables.tf). At a minimum you must set:
+   ```hcl
+   k3s_url   = "https://YOUR-CONTROL-PLANE:6443"
+   k3s_token = "YOUR-SECRET"
+
+   aws_key_name          = "your-aws-key"
+   aws_allowed_cidr      = "203.0.113.0/24" # tighten from 0.0.0.0/0 when possible
+
+   libvirt_pool          = "default"
+   libvirt_network       = "default"
+   libvirt_base_image    = "/var/lib/libvirt/images/ubuntu-22.04-server-cloudimg-amd64.img"
+   libvirt_ssh_public_key = "ssh-ed25519 AAAA..."
+   ```
+2. Export credentials before running Terraform:
+   ```bash
+   export AWS_PROFILE=your-profile # or configure AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY
+   export LIBVIRT_DEFAULT_URI=qemu:///system
+   ```
+3. Initialize Terraform and preview the plan:
+   ```bash
+   terraform init
+   terraform plan
+   ```
+4. Apply the configuration to create both worker nodes:
+   ```bash
+   terraform apply
+   ```
+5. When you no longer need the workers, destroy them to avoid incurring usage on your AWS account and to free resources on your libvirt host:
+   ```bash
+   terraform destroy
+   ```
+
+## Connection details
+
+Outputs expose connection hints for both workers. The AWS instance prints the public IP/DNS name, while the libvirt VM outputs its assigned IP address once the DHCP lease is visible to libvirt. You can SSH into either node with the same key pair used during provisioning.
+
+## Security considerations
+
+* Replace the default `0.0.0.0/0` SSH ingress CIDR with your own public IP range.
+* Rotate the K3s token regularly and store it securely (for example, using Terraform Cloud/Enterprise or environment variables instead of committing it to disk).
+* Review the generated user data scripts before applying to ensure they meet your organization's hardening standards.
+
+## Troubleshooting
+
+* If the libvirt VM does not receive an IP address immediately, run `virsh domifaddr <vm-name>` on the host or inspect the DHCP leases.
+* Ensure that the control-plane URL is reachable from both the AWS subnet and your on-prem network. You may need to adjust firewall rules or VPN tunnels to bridge the environments.
+* To use a different cloud provider, replace the resources defined in `cloud.tf` with equivalents from your provider while reusing the same K3s agent template.
+
+## Cleaning up generated files
+
+Terraform writes rendered cloud-init snippets into the local `rendered/` directory (ignored by Git). You can safely delete this directory after a successful destroy if you no longer need the generated files.

--- a/60-terraform/k3s-workers/cloud.tf
+++ b/60-terraform/k3s-workers/cloud.tf
@@ -1,0 +1,81 @@
+locals {
+  aws_tags = merge(var.tags, {
+    "Name" = "k3s-cloud-worker"
+  })
+}
+
+data "aws_ami" "amazon_linux_2023" {
+  most_recent = true
+
+  owners = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+resource "aws_security_group" "worker" {
+  name        = "k3s-worker-sg"
+  description = "Allow SSH and K3s traffic"
+  vpc_id      = var.aws_vpc_id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.aws_allowed_cidr]
+  }
+
+  ingress {
+    description = "K3s agent -> server"
+    from_port   = 6443
+    to_port     = 6443
+    protocol    = "tcp"
+    cidr_blocks = [var.aws_allowed_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = local.aws_tags
+}
+
+resource "aws_instance" "k3s_worker" {
+  ami                         = data.aws_ami.amazon_linux_2023.id
+  instance_type               = var.aws_instance_type
+  key_name                    = var.aws_key_name
+  subnet_id                   = var.aws_subnet_id
+  availability_zone           = var.aws_availability_zone
+  associate_public_ip_address = true
+  vpc_security_group_ids      = compact([aws_security_group.worker.id])
+
+  root_block_device {
+    volume_size = var.aws_root_volume_size
+    volume_type = "gp3"
+    encrypted   = true
+  }
+
+  user_data = templatefile("${path.module}/templates/k3s-agent.sh.tftpl", {
+    k3s_url   = var.k3s_url
+    k3s_token = var.k3s_token
+    node_name = "k3s-cloud-worker"
+  })
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = local.aws_tags
+}

--- a/60-terraform/k3s-workers/onprem.tf
+++ b/60-terraform/k3s-workers/onprem.tf
@@ -1,0 +1,85 @@
+locals {
+  libvirt_tags = merge(var.tags, {
+    "Name" = var.libvirt_vm_name
+  })
+
+  rendered_dir           = "${path.module}/rendered"
+  onprem_cloud_init_name = "${var.libvirt_vm_name}-cloud-init.yaml"
+  onprem_cloud_init_path = "${local.rendered_dir}/${local.onprem_cloud_init_name}"
+}
+
+resource "null_resource" "rendered_dir" {
+  triggers = {
+    path = local.rendered_dir
+  }
+
+  provisioner "local-exec" {
+    command = "mkdir -p ${local.rendered_dir}"
+  }
+}
+
+resource "local_file" "cloud_init" {
+  depends_on = [null_resource.rendered_dir]
+
+  filename = local.onprem_cloud_init_path
+  content  = templatefile("${path.module}/templates/cloud-init.yaml.tftpl", {
+    hostname  = var.libvirt_hostname
+    ssh_key   = var.libvirt_ssh_public_key
+    k3s_url   = var.k3s_url
+    k3s_token = var.k3s_token
+    node_name = var.libvirt_hostname
+  })
+}
+
+resource "libvirt_volume" "worker_disk" {
+  name   = "${var.libvirt_vm_name}.qcow2"
+  pool   = var.libvirt_pool
+  source = var.libvirt_base_image
+  format = "qcow2"
+  size   = var.libvirt_disk_size * 1024 * 1024 * 1024
+}
+
+resource "libvirt_cloudinit_disk" "cloudinit" {
+  name      = "${var.libvirt_vm_name}-cloudinit.iso"
+  pool      = var.libvirt_pool
+  user_data = local_file.cloud_init.content
+  meta_data = <<EOT
+{
+  "instance-id": "${var.libvirt_vm_name}",
+  "local-hostname": "${var.libvirt_hostname}"
+}
+EOT
+}
+
+resource "libvirt_domain" "worker" {
+  name   = var.libvirt_vm_name
+  memory = var.libvirt_memory_mb
+  vcpu   = var.libvirt_vcpu_count
+
+  cpu {
+    mode = "host-passthrough"
+  }
+
+  cloudinit = libvirt_cloudinit_disk.cloudinit.id
+
+  network_interface {
+    network_name   = var.libvirt_network
+    wait_for_lease = var.libvirt_wait_for_lease
+  }
+
+  disk {
+    volume_id = libvirt_volume.worker_disk.id
+  }
+
+  graphics {
+    type        = "spice"
+    listen_type = "address"
+    autoport    = true
+  }
+
+  console {
+    type        = "pty"
+    target_type = "serial"
+    target_port = "0"
+  }
+}

--- a/60-terraform/k3s-workers/outputs.tf
+++ b/60-terraform/k3s-workers/outputs.tf
@@ -1,0 +1,20 @@
+output "aws_worker_public_ip" {
+  description = "Public IPv4 address of the AWS-based worker node."
+  value       = aws_instance.k3s_worker.public_ip
+}
+
+output "aws_worker_public_dns" {
+  description = "Public DNS name of the AWS-based worker node."
+  value       = aws_instance.k3s_worker.public_dns
+}
+
+output "onprem_worker_ip" {
+  description = "Discovered IPv4 address of the libvirt worker (requires DHCP lease)."
+  value       = libvirt_domain.worker.network_interface[0].addresses
+}
+
+output "rendered_cloud_init" {
+  description = "Local path to the rendered cloud-init file used for the on-prem worker."
+  value       = local_file.cloud_init.filename
+  sensitive   = true
+}

--- a/60-terraform/k3s-workers/providers.tf
+++ b/60-terraform/k3s-workers/providers.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "~> 0.7"
+    }
+
+    template = {
+      source  = "hashicorp/template"
+      version = "~> 2.2"
+    }
+
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.4"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "libvirt" {
+  uri = var.libvirt_uri
+}

--- a/60-terraform/k3s-workers/templates/cloud-init.yaml.tftpl
+++ b/60-terraform/k3s-workers/templates/cloud-init.yaml.tftpl
@@ -1,0 +1,31 @@
+#cloud-config
+hostname: ${hostname}
+users:
+  - name: ubuntu
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: users, admin, sudo
+    ssh_authorized_keys:
+      - ${ssh_key}
+package_update: true
+package_upgrade: true
+packages:
+  - curl
+  - qemu-guest-agent
+write_files:
+  - path: /usr/local/bin/k3s-agent-install.sh
+    permissions: '0755'
+    owner: root:root
+    content: |
+      #!/bin/bash
+      set -euxo pipefail
+      curl -sfL https://get.k3s.io | \
+        INSTALL_K3S_EXEC="--node-name ${node_name} --node-label location=onprem" \
+        K3S_URL="${k3s_url}" \
+        K3S_TOKEN="${k3s_token}" \
+        sh -
+      systemctl enable k3s-agent
+      systemctl start k3s-agent
+runcmd:
+  - [ bash, -c, '/usr/local/bin/k3s-agent-install.sh' ]
+  - [ systemctl, enable, qemu-guest-agent ]
+  - [ systemctl, start, qemu-guest-agent ]

--- a/60-terraform/k3s-workers/templates/k3s-agent.sh.tftpl
+++ b/60-terraform/k3s-workers/templates/k3s-agent.sh.tftpl
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euxo pipefail
+
+yum update -y
+
+yum install -y curl
+
+# Harden SSH: disable password authentication
+sed -i 's/^PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+echo "ClientAliveInterval 120" >> /etc/ssh/sshd_config
+echo "ClientAliveCountMax 2" >> /etc/ssh/sshd_config
+systemctl restart sshd
+
+curl -sfL https://get.k3s.io | \
+  INSTALL_K3S_EXEC="--node-name ${node_name} --node-label location=aws" \
+  K3S_URL="${k3s_url}" \
+  K3S_TOKEN="${k3s_token}" \
+  sh -

--- a/60-terraform/k3s-workers/variables.tf
+++ b/60-terraform/k3s-workers/variables.tf
@@ -1,0 +1,134 @@
+variable "k3s_url" {
+  description = "URL of the existing K3s control-plane (for example, https://10.0.0.10:6443)."
+  type        = string
+}
+
+variable "k3s_token" {
+  description = "Shared K3s cluster token used to register new worker nodes."
+  type        = string
+  sensitive   = true
+}
+
+variable "aws_region" {
+  description = "AWS region in which to provision the free-tier worker."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_instance_type" {
+  description = "Instance type for the AWS worker. Defaults to the free-tier eligible t2.micro."
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "aws_key_name" {
+  description = "Name of the existing AWS EC2 key pair to associate with the worker instance."
+  type        = string
+}
+
+variable "aws_allowed_cidr" {
+  description = "CIDR block allowed to SSH into the AWS worker. Replace 0.0.0.0/0 with a restricted range for production."
+  type        = string
+  default     = "0.0.0.0/0"
+}
+
+variable "aws_vpc_id" {
+  description = "Optional VPC ID for the worker. If unset, the default VPC for the region is used."
+  type        = string
+  default     = null
+}
+
+variable "aws_subnet_id" {
+  description = "Optional subnet ID. If null, the default subnet for the chosen availability zone is used."
+  type        = string
+  default     = null
+}
+
+variable "aws_availability_zone" {
+  description = "Optional availability zone for the worker."
+  type        = string
+  default     = null
+}
+
+variable "aws_root_volume_size" {
+  description = "Root volume size (GiB) for the AWS worker."
+  type        = number
+  default     = 20
+}
+
+variable "libvirt_uri" {
+  description = "Libvirt URI of the on-prem host (for example, qemu:///system)."
+  type        = string
+  default     = "qemu:///system"
+}
+
+variable "libvirt_pool" {
+  description = "Name of the libvirt storage pool that contains the base cloud image."
+  type        = string
+}
+
+variable "libvirt_network" {
+  description = "Name of the libvirt network to connect the VM to."
+  type        = string
+}
+
+variable "libvirt_base_image" {
+  description = "Absolute path to the Ubuntu 22.04 cloud image inside the libvirt storage pool."
+  type        = string
+}
+
+variable "libvirt_disk_size" {
+  description = "Disk size in GiB for the on-prem worker."
+  type        = number
+  default     = 20
+}
+
+variable "libvirt_memory_mb" {
+  description = "RAM in MiB for the on-prem worker."
+  type        = number
+  default     = 2048
+}
+
+variable "libvirt_vcpu_count" {
+  description = "Number of vCPUs for the on-prem worker."
+  type        = number
+  default     = 2
+}
+
+variable "libvirt_vm_name" {
+  description = "Name to assign to the on-prem worker virtual machine."
+  type        = string
+  default     = "k3s-onprem-worker"
+}
+
+variable "libvirt_hostname" {
+  description = "Hostname to configure inside the on-prem worker."
+  type        = string
+  default     = "k3s-onprem-worker"
+}
+
+variable "libvirt_ssh_public_key" {
+  description = "SSH public key content injected into the on-prem worker for remote access."
+  type        = string
+}
+
+variable "libvirt_network_interface" {
+  description = "Name of the libvirt network interface definition to attach (defaults to using the network bridge)."
+  type        = string
+  default     = "default"
+}
+
+variable "libvirt_wait_for_lease" {
+  description = "Whether to wait for an IP lease to become available before finishing apply."
+  type        = bool
+  default     = true
+}
+
+variable "tags" {
+  description = "Map of tags/labels applied to both workers."
+  type        = map(string)
+  default = {
+    "Project" = "hb-suite"
+    "Role"    = "k3s-worker"
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration for provisioning an AWS free-tier friendly worker node and an on-prem libvirt VM
- bootstrap both nodes with K3s agent configuration so they automatically join an existing control-plane
- document prerequisites, usage, and cleanup steps for the hybrid worker deployment

## Testing
- not run (terraform CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e1335430348322a5e44245f0d38308

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add Terraform configuration to provision two K3s worker nodes (one in AWS, one on-prem) with automated cloud-init bootstrap.
  - Provide configurable variables for regions, instance specs, networking, and cluster join details.
  - Expose outputs for public IP/DNS (cloud) and discovered IP (on-prem) to simplify access.
  - Improve default security posture with SSH hardening and restricted metadata access.

- Documentation
  - New README with prerequisites, setup steps, usage, connection details, troubleshooting, and cleanup.

- Chores
  - Update .gitignore to exclude rendered artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->