### PR TITLE
Update Traefik middleware API group and ingress annotations

### DIFF
--- a/10-configmaps/traefik-middlewares.yaml
+++ b/10-configmaps/traefik-middlewares.yaml
@@ -1,27 +1,27 @@
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: suite-redirect-https
+  name: redirect-https
   namespace: suite
 spec:
   redirectScheme:
     scheme: https
     permanent: true
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: suite-allow-lan
+  name: allow-lan
   namespace: suite
 spec:
   ipWhiteList:
     sourceRange:
       - 192.168.50.0/24
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: suite-security-headers
+  name: security-headers
   namespace: suite
 spec:
   headers:
@@ -30,10 +30,10 @@ spec:
     browserXssFilter: true
     stsSeconds: 31536000
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: suite-compress
+  name: compress
   namespace: suite
 spec:
   compress: {}

--- a/40-ingress/mirror-ingress.yaml
+++ b/40-ingress/mirror-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: suite
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
-    traefik.ingress.kubernetes.io/router.middlewares: suite-suite-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: suite-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/40-ingress/pihole-ui.yaml
+++ b/40-ingress/pihole-ui.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: suite
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web
-    traefik.ingress.kubernetes.io/router.middlewares: suite-suite-allow-lan@kubernetescrd,suite-suite-security-headers@kubernetescrd,suite-suite-compress@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: suite-allow-lan@kubernetescrd,suite-security-headers@kubernetescrd,suite-compress@kubernetescrd
 spec:
   ingressClassName: traefik
   rules:

--- a/40-ingress/suite-apps.yaml
+++ b/40-ingress/suite-apps.yaml
@@ -4,7 +4,7 @@ metadata:
   name: suite-apps
   namespace: suite
   annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: suite-suite-redirect-https@kubernetescrd
+    traefik.ingress.kubernetes.io/router.middlewares: suite-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik
   tls:


### PR DESCRIPTION
## Summary
- update the Traefik middleware manifests to use the `traefik.io/v1alpha1` API group and simplified names
- refresh the suite ingress annotations to reference the renamed middlewares

## Testing
- not run (configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68ea594ec4e88322aa977c415e0e4360

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Corrected Ingress middleware annotations to reference updated names, ensuring HTTPS redirect, LAN allowlist, security headers, and compression are applied as expected.
- Refactor
  - Renamed Traefik middlewares to shorter, consistent names.
- Chores
  - Updated Traefik CRD API version to traefik.io/v1alpha1 for Middleware resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->