### PR TITLE
Use Longhorn storage class for homebridge PVCs

### DIFF
--- a/20-storage/homebridge-pvcs.yaml
+++ b/20-storage/homebridge-pvcs.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes: ["ReadWriteOnce"]
   resources: { requests: { storage: 10Gi } }
-  storageClassName: local-path
+  storageClassName: longhorn
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -16,4 +16,4 @@ metadata:
 spec:
   accessModes: ["ReadWriteOnce"]
   resources: { requests: { storage: 2Gi } }
-  storageClassName: local-path
+  storageClassName: longhorn


### PR DESCRIPTION
## Summary
- switch the Homebridge data and backup PVCs to use the Longhorn storage class for provisioning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f12951ca508322b75478f129c11c1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated storage configuration to use Longhorn storage class for homebridge data and backup volumes, replacing the previous local-path storage configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->