### PR TITLE
Add Longhorn PVCs and migration workflow for Homebridge

### DIFF
--- a/20-storage/homebridge-pvcs.yaml
+++ b/20-storage/homebridge-pvcs.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: homebridge-data
+  name: homebridge-data-longhorn
   namespace: suite
 spec:
   accessModes: ["ReadWriteOnce"]
   resources: { requests: { storage: 10Gi } }
-  storageClassName: local-path
+  storageClassName: longhorn
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: homebridge-backups
+  name: homebridge-backups-longhorn
   namespace: suite
 spec:
   accessModes: ["ReadWriteOnce"]
   resources: { requests: { storage: 2Gi } }
-  storageClassName: local-path
+  storageClassName: longhorn

--- a/30-apps/homebridge.yaml
+++ b/30-apps/homebridge.yaml
@@ -28,7 +28,7 @@ spec:
             - { name: data, mountPath: /homebridge }
       volumes:
         - name: data
-          persistentVolumeClaim: { claimName: homebridge-data }
+          persistentVolumeClaim: { claimName: homebridge-data-longhorn }
 ---
 apiVersion: v1
 kind: Service

--- a/50-ops/homebridge-backup-cron.yaml
+++ b/50-ops/homebridge-backup-cron.yaml
@@ -24,5 +24,5 @@ spec:
                 - { name: hb, mountPath: /homebridge }
                 - { name: bkp, mountPath: /backups }
           volumes:
-            - { name: hb,  persistentVolumeClaim: { claimName: homebridge-data } }
-            - { name: bkp, persistentVolumeClaim: { claimName: homebridge-backups } }
+            - { name: hb,  persistentVolumeClaim: { claimName: homebridge-data-longhorn } }
+            - { name: bkp, persistentVolumeClaim: { claimName: homebridge-backups-longhorn } }

--- a/50-ops/homebridge-backup-now-job.yaml
+++ b/50-ops/homebridge-backup-now-job.yaml
@@ -21,5 +21,5 @@ spec:
             - { name: hb, mountPath: /homebridge }
             - { name: bkp, mountPath: /backups }
       volumes:
-        - { name: hb,  persistentVolumeClaim: { claimName: homebridge-data } }
-        - { name: bkp, persistentVolumeClaim: { claimName: homebridge-backups } }
+        - { name: hb,  persistentVolumeClaim: { claimName: homebridge-data-longhorn } }
+        - { name: bkp, persistentVolumeClaim: { claimName: homebridge-backups-longhorn } }

--- a/50-ops/homebridge-migrate-to-longhorn-job.yaml
+++ b/50-ops/homebridge-migrate-to-longhorn-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: homebridge-migrate-to-longhorn
+  namespace: suite
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: alpine:3.20
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              apk add --no-cache rsync > /dev/null
+              if [ ! -d /src-data ] || [ -z "$(ls -A /src-data 2>/dev/null)" ]; then
+                echo "No files found in legacy homebridge-data PVC, skipping copy"
+              elif [ -n "$(ls -A /dst-data 2>/dev/null)" ]; then
+                echo "homebridge-data-longhorn already populated, skipping copy"
+              else
+                rsync -a /src-data/ /dst-data/
+                echo "Copied data volume contents"
+              fi
+
+              if [ ! -d /src-backups ] || [ -z "$(ls -A /src-backups 2>/dev/null)" ]; then
+                echo "No files found in legacy homebridge-backups PVC, skipping copy"
+              elif [ -n "$(ls -A /dst-backups 2>/dev/null)" ]; then
+                echo "homebridge-backups-longhorn already populated, skipping copy"
+              else
+                rsync -a /src-backups/ /dst-backups/
+                echo "Copied backup volume contents"
+              fi
+          volumeMounts:
+            - { name: legacy-data, mountPath: /src-data, readOnly: true }
+            - { name: new-data,    mountPath: /dst-data }
+            - { name: legacy-backups, mountPath: /src-backups, readOnly: true }
+            - { name: new-backups,    mountPath: /dst-backups }
+      volumes:
+        - { name: legacy-data,     persistentVolumeClaim: { claimName: homebridge-data } }
+        - { name: new-data,        persistentVolumeClaim: { claimName: homebridge-data-longhorn } }
+        - { name: legacy-backups,  persistentVolumeClaim: { claimName: homebridge-backups } }
+        - { name: new-backups,     persistentVolumeClaim: { claimName: homebridge-backups-longhorn } }

--- a/50-ops/homebridge-restore-job.yaml
+++ b/50-ops/homebridge-restore-job.yaml
@@ -27,5 +27,5 @@ spec:
             - { name: hb, mountPath: /homebridge }
             - { name: bkp, mountPath: /backups }
       volumes:
-        - { name: hb,  persistentVolumeClaim: { claimName: homebridge-data } }
-        - { name: bkp, persistentVolumeClaim: { claimName: homebridge-backups } }
+        - { name: hb,  persistentVolumeClaim: { claimName: homebridge-data-longhorn } }
+        - { name: bkp, persistentVolumeClaim: { claimName: homebridge-backups-longhorn } }


### PR DESCRIPTION
## Summary
- create new Longhorn-backed PVCs for Homebridge data and backups
- update the Homebridge deployment and backup jobs to consume the new claims
- add a one-time migration job and document the steps to copy data from the legacy volumes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f12951ca508322b75478f129c11c1f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Longhorn migration guide with step-by-step instructions and prerequisites.
  * Updated restore instructions for updated storage configuration.
  * Added note about Traefik CRD availability.

* **Chores**
  * Migrated storage configuration to Longhorn across all workloads.
  * Added automated data migration job for seamless transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->