### PR TITLE
Add Jenkins pipeline for workflow validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,49 @@
+pipeline {
+  agent any
+
+  options {
+    ansiColor('xterm')
+    timestamps()
+  }
+
+  stages {
+    stage('Checkout') {
+      steps {
+        checkout scm
+      }
+    }
+
+    stage('Validate Kubernetes manifests') {
+      agent {
+        docker {
+          image 'bitnami/kubectl:1.27.4'
+          args '-u root:root'
+        }
+      }
+      steps {
+        sh 'bash scripts/ci/validate-kubernetes-manifests.sh'
+      }
+    }
+
+    stage('Terraform formatting check') {
+      agent {
+        docker {
+          image 'hashicorp/terraform:1.5.7'
+          args '-u root:root'
+        }
+      }
+      steps {
+        sh 'bash scripts/ci/check-terraform-format.sh'
+      }
+    }
+  }
+
+  post {
+    success {
+      echo 'All workflow checks passed successfully.'
+    }
+    failure {
+      echo 'Workflow checks failed. Review the stage logs for details.'
+    }
+  }
+}

--- a/scripts/ci/check-terraform-format.sh
+++ b/scripts/ci/check-terraform-format.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+if ! command -v terraform >/dev/null 2>&1; then
+  echo "terraform not found on PATH. Install Terraform or run inside a container image that provides it." >&2
+  exit 1
+fi
+
+declare -A module_dirs=()
+while IFS= read -r tf_file; do
+  dir="$(dirname "$tf_file")"
+  module_dirs["$dir"]=1
+done < <(find "$REPO_ROOT" -type f -name '*.tf' ! -path '*/.terraform/*')
+
+if [ "${#module_dirs[@]}" -eq 0 ]; then
+  echo "No Terraform modules found. Skipping format check."
+  exit 0
+fi
+
+status=0
+for dir in "${!module_dirs[@]}"; do
+  rel_path="${dir#$REPO_ROOT/}"
+  echo "Checking Terraform formatting in ${rel_path}"
+  if ! (cd "$dir" && terraform fmt -check -recursive); then
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "Terraform formatting check failed." >&2
+else
+  echo "Terraform formatting is correct."
+fi
+
+exit "$status"

--- a/scripts/ci/run-common-workflow-tests.sh
+++ b/scripts/ci/run-common-workflow-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+"${SCRIPT_DIR}/validate-kubernetes-manifests.sh"
+"${SCRIPT_DIR}/check-terraform-format.sh"

--- a/scripts/ci/validate-kubernetes-manifests.sh
+++ b/scripts/ci/validate-kubernetes-manifests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+if ! command -v kubectl >/dev/null 2>&1; then
+  echo "kubectl not found on PATH. Install kubectl or run inside a container image that provides it." >&2
+  exit 1
+fi
+
+mapfile -t manifests < <(find "$REPO_ROOT" -type f \( -name '*.yml' -o -name '*.yaml' \) ! -name '*:Zone.Identifier' ! -path '*/.terraform/*' ! -path '*/.git/*' | sort)
+
+if [ "${#manifests[@]}" -eq 0 ]; then
+  echo "No Kubernetes manifests found. Skipping validation."
+  exit 0
+fi
+
+status=0
+for manifest in "${manifests[@]}"; do
+  rel_path="${manifest#$REPO_ROOT/}"
+  echo "Validating ${rel_path}"
+  if ! kubectl apply --dry-run=client --validate=true --filename "$manifest" >/tmp/kubectl-validate.log 2>&1; then
+    echo "Validation failed for ${rel_path}" >&2
+    cat /tmp/kubectl-validate.log >&2
+    status=1
+  fi
+  rm -f /tmp/kubectl-validate.log
+done
+
+if [ "$status" -ne 0 ]; then
+  echo "One or more Kubernetes manifests failed validation." >&2
+else
+  echo "All Kubernetes manifests validated successfully."
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary
- add a declarative Jenkins pipeline that runs Kubernetes manifest validation and Terraform formatting checks in containerized stages
- provide reusable CI helper scripts to validate YAML manifests and enforce Terraform fmt checks

## Testing
- bash -n scripts/ci/validate-kubernetes-manifests.sh
- bash -n scripts/ci/check-terraform-format.sh
- bash -n scripts/ci/run-common-workflow-tests.sh


------
https://chatgpt.com/codex/tasks/task_e_68f135e522fc8322b02d3188579b6ec3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CI/CD pipeline configuration with automated validation stages
  * Added infrastructure validation scripts to ensure configuration consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->