### PR TITLE
Add TLS-enabled ingress for MagicMirror deployment

### DIFF
--- a/40-ingress/mirror-ingress.yaml
+++ b/40-ingress/mirror-ingress.yaml
@@ -1,18 +1,24 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: mirror-ingress
+  name: magicmirror
   namespace: suite
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.middlewares: suite-redirect-https@kubernetescrd
 spec:
   ingressClassName: traefik
+  tls:
+    - secretName: suite-home-arpa-tls
+      hosts: ["magicmirror.suite.home.arpa"]
   rules:
-    - host: mirror.suite.home.arpa
+    - host: magicmirror.suite.home.arpa
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
-              service: { name: magicmirror-server, port: { number: 8080 } }
+              service:
+                name: magicmirror-server
+                port:
+                  number: 8080


### PR DESCRIPTION
## Summary
- update the magicmirror ingress to target the magicmirror-server service
- add TLS configuration for magicmirror.suite.home.arpa so the app is exposed over HTTPS

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_69076b63a340832296fa9724ee728408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added TLS/SSL encryption support to the ingress configuration for secure access
  * Updated service routing configuration and ingress hostname mappings to align with new security settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->