### PR TITLE
Add Kubernetes manifests for Jenkins server

### DIFF
--- a/20-storage/jenkins-pvc.yaml
+++ b/20-storage/jenkins-pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jenkins-home
+  namespace: suite
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources: { requests: { storage: 20Gi } }
+  storageClassName: longhorn

--- a/30-apps/jenkins.yaml
+++ b/30-apps/jenkins.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins
+  namespace: suite
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jenkins-cluster-admin
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+  - nonResourceURLs: ["*"]
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: jenkins-cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: jenkins
+    namespace: suite
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jenkins-cluster-admin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins
+  namespace: suite
+spec:
+  selector: { matchLabels: { app: jenkins } }
+  replicas: 1
+  template:
+    metadata: { labels: { app: jenkins } }
+    spec:
+      serviceAccountName: jenkins
+      securityContext: { fsGroup: 1000 }
+      containers:
+        - name: jenkins
+          image: jenkins/jenkins:lts-jdk17
+          imagePullPolicy: IfNotPresent
+          env:
+            - { name: JAVA_OPTS, value: "-Djenkins.install.runSetupWizard=false" }
+          ports:
+            - { containerPort: 8080, name: http }
+            - { containerPort: 50000, name: agent }
+          readinessProbe:
+            httpGet: { path: /login, port: 8080 }
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /login, port: 8080 }
+            initialDelaySeconds: 60
+            periodSeconds: 20
+          resources:
+            requests: { cpu: "500m", memory: "1Gi" }
+            limits: { cpu: "1", memory: "2Gi" }
+          volumeMounts:
+            - { name: jenkins-home, mountPath: /var/jenkins_home }
+      volumes:
+        - name: jenkins-home
+          persistentVolumeClaim: { claimName: jenkins-home }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins
+  namespace: suite
+spec:
+  selector: { app: jenkins }
+  ports:
+    - { name: http, port: 8080, targetPort: 8080 }
+    - { name: agent, port: 50000, targetPort: 50000 }
+  type: ClusterIP

--- a/40-ingress/jenkins.yaml
+++ b/40-ingress/jenkins.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jenkins
+  namespace: suite
+  annotations:
+    traefik.ingress.kubernetes.io/router.middlewares: suite-redirect-https@kubernetescrd
+spec:
+  ingressClassName: traefik
+  tls:
+    - secretName: suite-home-arpa-tls
+      hosts: ["jenkins.suite.home.arpa"]
+  rules:
+    - host: jenkins.suite.home.arpa
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service: { name: jenkins, port: { number: 8080 } }


### PR DESCRIPTION
## Summary
- add a persistent volume claim for Jenkins home data in the suite namespace
- deploy Jenkins with a service account, RBAC, deployment, and service definitions
- expose the Jenkins UI through a Traefik ingress using the existing TLS secret

## Testing
- `bash scripts/ci/validate-kubernetes-manifests.sh` *(fails: kubectl not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_69076e32cb108322af5ca889bc93332b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jenkins deployment now available with persistent storage
  * Accessible via jenkins.suite.home.arpa with TLS encryption
  * Includes integrated health monitoring and container resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->