### PR TITLE
Add touchscreen reconfiguration helper

### DIFF
--- a/car-dashboard/README.md
+++ b/car-dashboard/README.md
@@ -71,6 +71,15 @@ AUTOSTART
 
 Reboot after installing the systemd service and Chromium will launch directly into the dashboard at `http://localhost:8000`.
 
+### Improve touchscreen responsiveness
+If taps feel sluggish or require extra pressure, apply the bundled libinput tuning so the Pi's touchscreen accepts lighter touches. Run the helper from the repository root on the Raspberry Pi:
+
+```bash
+sudo ./scripts/reconfigure-touchscreen.sh
+```
+
+The script writes `/etc/udev/hwdb.d/99-car-touchscreen.hwdb` with more permissive pressure and jitter thresholds for the official 7" DSI panel (FT5406) and common Goodix/GT911 USB overlays. It then reloads the hardware database; reboot once to ensure the new attributes are active.
+
 ## Configuring data providers
 Set the `CAR_DASH_PROVIDER` environment variable to one of:
 - `mock` (default) – Generates synthetic but realistic-looking data for demos.

--- a/scripts/reconfigure-touchscreen.sh
+++ b/scripts/reconfigure-touchscreen.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Apply libinput/udev tuning to make common Raspberry Pi touchscreens feel more responsive.
+# Run this on the Pi with sudo: sudo ./scripts/reconfigure-touchscreen.sh
+set -euo pipefail
+
+if [[ $EUID -ne 0 ]]; then
+  echo "This script must be run as root (sudo)." >&2
+  exit 1
+fi
+
+HWDB_PATH="/etc/udev/hwdb.d/99-car-touchscreen.hwdb"
+
+cat >"${HWDB_PATH}" <<'HWDB'
+# Touchscreen responsiveness tuning for the Raspberry Pi dashboard
+# Applies to the official 7" DSI display (FT5406) and common Goodix/GT911 controllers.
+evdev:name:FT5406*:dmi:*Raspberry_Pi*
+ LIBINPUT_ATTR_TOUCH_SIZE_RANGE=0:3
+ LIBINPUT_ATTR_PRESSURE_RANGE=0:15
+ LIBINPUT_ATTR_PALM_PRESSURE_THRESHOLD=120
+ LIBINPUT_ATTR_TOUCHSCREEN_SMOOTHING=true
+ LIBINPUT_ATTR_TOUCHSCREEN_TAP_JITTER=8
+
+# Goodix/GT911 fallback
+# These devices are widely used on HDMI touch overlays and USB touch kits.
+evdev:name:Goodix*:dmi:*Raspberry_Pi*|evdev:name:GT911*:dmi:*Raspberry_Pi*
+ LIBINPUT_ATTR_TOUCH_SIZE_RANGE=0:3
+ LIBINPUT_ATTR_PRESSURE_RANGE=0:15
+ LIBINPUT_ATTR_PALM_PRESSURE_THRESHOLD=120
+ LIBINPUT_ATTR_TOUCHSCREEN_SMOOTHING=true
+ LIBINPUT_ATTR_TOUCHSCREEN_TAP_JITTER=8
+HWDB
+
+# Refresh udev database so the new attributes are picked up.
+systemd-hwdb update
+udevadm trigger /dev/input/event*
+
+echo "Touchscreen tuning installed at ${HWDB_PATH}. Reboot to ensure the new libinput attributes take effect."


### PR DESCRIPTION
## Summary
- add a touchscreen reconfiguration script that installs libinput tuning for common Raspberry Pi panels
- document how to apply the tuning from the Raspberry Pi dashboard README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691faa2a1a288322ad62064fd577d6f5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added touchscreen tuning script to improve touch responsiveness on compatible devices.

* **Documentation**
  * Added instructions for running the touchscreen tuning utility and applying optimized touch controller settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->